### PR TITLE
Add add-policy-coverage route, extend Send to support CC argument

### DIFF
--- a/comms/email/email.go
+++ b/comms/email/email.go
@@ -5,11 +5,12 @@ import "encoding/json"
 type TplID string
 
 const (
-	TplAddPolicyVehicle TplID = "add-policy-vehicle"
-	TplAddPolicyDriver  TplID = "add-policy-driver"
-	TplAddPolicyAddress TplID = "add-policy-address"
+	TplAddPolicyVehicle  TplID = "add-policy-vehicle"
+	TplAddPolicyDriver   TplID = "add-policy-driver"
+	TplAddPolicyCoverage TplID = "add-policy-coverage"
+	TplAddPolicyAddress  TplID = "add-policy-address"
 )
 
 type MailProvider interface {
-	Send(to []string, message json.RawMessage, tpl TplID) error
+	Send(to []string, cc []string, message json.RawMessage, tpl TplID) error
 }

--- a/comms/email/email.go
+++ b/comms/email/email.go
@@ -12,5 +12,5 @@ const (
 )
 
 type MailProvider interface {
-	Send(to []string, cc []string, message json.RawMessage, tpl TplID) error
+	Send(tos []string, ccs []string, message json.RawMessage, tpl TplID) error
 }

--- a/comms/email/mockemail/mockemail.go
+++ b/comms/email/mockemail/mockemail.go
@@ -16,11 +16,12 @@ func NewClient() *Client {
 	}
 }
 
-func (c *Client) Send(to []string, message json.RawMessage, tplID email.TplID) error {
+func (c *Client) Send(to []string, cc []string, message json.RawMessage, tplID email.TplID) error {
 
 	for _, v := range to {
 		c.sendLogs = append(c.sendLogs, SendLog{
 			to:      v,
+			cc:      cc,
 			message: message,
 			tplID:   tplID,
 		})

--- a/comms/email/mockemail/mockemail.go
+++ b/comms/email/mockemail/mockemail.go
@@ -16,16 +16,13 @@ func NewClient() *Client {
 	}
 }
 
-func (c *Client) Send(to []string, cc []string, message json.RawMessage, tplID email.TplID) error {
-
-	for _, v := range to {
-		c.sendLogs = append(c.sendLogs, SendLog{
-			to:      v,
-			cc:      cc,
-			message: message,
-			tplID:   tplID,
-		})
-	}
+func (c *Client) Send(tos []string, ccs []string, message json.RawMessage, tplID email.TplID) error {
+	c.sendLogs = append(c.sendLogs, SendLog{
+		tos:     tos,
+		ccs:     ccs,
+		message: message,
+		tplID:   tplID,
+	})
 
 	return nil
 }

--- a/comms/email/mockemail/sendlog.go
+++ b/comms/email/mockemail/sendlog.go
@@ -8,12 +8,17 @@ import (
 
 type SendLog struct {
 	to      string
+	cc      []string
 	tplID   email.TplID
 	message json.RawMessage
 }
 
 func (sl *SendLog) ExtractTo() string {
 	return sl.to
+}
+
+func (sl *SendLog) ExtractCC() []string {
+	return sl.cc
 }
 
 func (sl *SendLog) ExtractTplID() email.TplID {

--- a/comms/email/mockemail/sendlog.go
+++ b/comms/email/mockemail/sendlog.go
@@ -7,18 +7,18 @@ import (
 )
 
 type SendLog struct {
-	to      string
-	cc      []string
+	tos     []string
+	ccs     []string
 	tplID   email.TplID
 	message json.RawMessage
 }
 
-func (sl *SendLog) ExtractTo() string {
-	return sl.to
+func (sl *SendLog) ExtractTos() []string {
+	return sl.tos
 }
 
-func (sl *SendLog) ExtractCC() []string {
-	return sl.cc
+func (sl *SendLog) ExtractCCs() []string {
+	return sl.ccs
 }
 
 func (sl *SendLog) ExtractTplID() email.TplID {

--- a/comms/email/sendgrid/sendgrid.go
+++ b/comms/email/sendgrid/sendgrid.go
@@ -30,11 +30,12 @@ type Client struct {
 	fromName    string
 }
 
-func (c *Client) Send(to []string, message json.RawMessage, tpl email.TplID) error {
+func (c *Client) Send(to []string, cc []string, message json.RawMessage, tpl email.TplID) error {
 
 	// create personalization
 	p := mail.NewPersonalization().
-		AddTos(to...)
+		AddTos(to...).
+		AddCCs(cc...)
 
 	// create the email
 	m := mail.NewV3Mail().

--- a/comms/email/sendgrid/sendgrid.go
+++ b/comms/email/sendgrid/sendgrid.go
@@ -30,12 +30,12 @@ type Client struct {
 	fromName    string
 }
 
-func (c *Client) Send(to []string, cc []string, message json.RawMessage, tpl email.TplID) error {
+func (c *Client) Send(tos []string, ccs []string, message json.RawMessage, tpl email.TplID) error {
 
 	// create personalization
 	p := mail.NewPersonalization().
-		AddTos(to...).
-		AddCCs(cc...)
+		AddTos(tos...).
+		AddCCs(ccs...)
 
 	// create the email
 	m := mail.NewV3Mail().

--- a/comms/handlers/handlers.go
+++ b/comms/handlers/handlers.go
@@ -23,7 +23,7 @@ func AddPolicyVehicle(emailsvc email.MailProvider) http.HandlerFunc {
 			return
 		}
 
-		if err := emailsvc.Send([]string{payload.EmailTo}, payload.Message, email.TplAddPolicyVehicle); err != nil {
+		if err := emailsvc.Send([]string{payload.EmailTo}, []string{}, payload.Message, email.TplAddPolicyVehicle); err != nil {
 			http.Error(w, fmt.Sprintf("error sending email: %v", err), http.StatusInternalServerError)
 			return
 		}
@@ -44,7 +44,28 @@ func AddPolicyDriver(emailsvc email.MailProvider) http.HandlerFunc {
 			return
 		}
 
-		if err := emailsvc.Send([]string{payload.EmailTo}, payload.Message, email.TplAddPolicyDriver); err != nil {
+		if err := emailsvc.Send([]string{payload.EmailTo}, []string{}, payload.Message, email.TplAddPolicyDriver); err != nil {
+			http.Error(w, fmt.Sprintf("error sending email: %v", err), http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
+func AddPolicyCoverage(emailsvc email.MailProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+
+		payload := AddPolicyCoverageReq{}
+
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "invalid payload", http.StatusBadRequest)
+			return
+		}
+
+		if err := emailsvc.Send([]string{payload.EmailTo}, []string{payload.EmailCC}, payload.Message, email.TplAddPolicyCoverage); err != nil {
 			http.Error(w, fmt.Sprintf("error sending email: %v", err), http.StatusInternalServerError)
 			return
 		}
@@ -65,7 +86,7 @@ func AddPolicyAddress(emailsvc email.MailProvider) http.HandlerFunc {
 			return
 		}
 
-		if err := emailsvc.Send([]string{payload.EmailTo}, payload.Message, email.TplAddPolicyAddress); err != nil {
+		if err := emailsvc.Send([]string{payload.EmailTo}, []string{}, payload.Message, email.TplAddPolicyAddress); err != nil {
 			http.Error(w, fmt.Sprintf("error sending email: %v", err), http.StatusInternalServerError)
 			return
 		}

--- a/comms/handlers/handlers.go
+++ b/comms/handlers/handlers.go
@@ -65,7 +65,7 @@ func AddPolicyCoverage(emailsvc email.MailProvider) http.HandlerFunc {
 			return
 		}
 
-		if err := emailsvc.Send([]string{payload.EmailTo}, []string{payload.EmailCC}, payload.Message, email.TplAddPolicyCoverage); err != nil {
+		if err := emailsvc.Send(payload.EmailTo, payload.EmailCC, payload.Message, email.TplAddPolicyCoverage); err != nil {
 			http.Error(w, fmt.Sprintf("error sending email: %v", err), http.StatusInternalServerError)
 			return
 		}

--- a/comms/handlers/handlers_test.go
+++ b/comms/handlers/handlers_test.go
@@ -212,6 +212,29 @@ func TestAddPolicyCoverage(t *testing.T) {
 			expectTplID:  email.TplAddPolicyCoverage,
 			expectStatus: http.StatusOK,
 		},
+		// NOTE: this passes in this faked sendgrid scenario, but I imagine sengrid
+		// would error if passed no tos and we'd either have to handle the error or
+		// catch empty tos at the route handler level
+		"pass empty to": {
+			method: http.MethodPost,
+			payload: handlers.AddPolicyCoverageReq{
+				EmailTo: []string{},
+				EmailCC: []string{"baz@bar.com"},
+				Message: json.RawMessage(`{"foo":"bar"}`),
+			},
+			expectTplID:  email.TplAddPolicyCoverage,
+			expectStatus: http.StatusOK,
+		},
+		"pass empty cc": {
+			method: http.MethodPost,
+			payload: handlers.AddPolicyCoverageReq{
+				EmailTo: []string{"foo@bar.com"},
+				EmailCC: []string{},
+				Message: json.RawMessage(`{"foo":"bar"}`),
+			},
+			expectTplID:  email.TplAddPolicyCoverage,
+			expectStatus: http.StatusOK,
+		},
 		"pass 2 to": {
 			method: http.MethodPost,
 			payload: handlers.AddPolicyCoverageReq{

--- a/comms/handlers/handlers_test.go
+++ b/comms/handlers/handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/gloveboxhq/glovebox-go-code-challenge/comms/email"
@@ -70,19 +71,8 @@ func TestAddPolicyVehicle(t *testing.T) {
 
 				lastEmail := testEmail.SendLogs().Last()
 
-				tos := lastEmail.ExtractTos()
-				expectedTos := []string{tc.payload.EmailTo}
-
-				if len(tos) != len(expectedTos) {
-					t.Fatalf("mismatched to lengths, expected %v but got %v", expectedTos, tos)
-				}
-
-				for i := range tos {
-					to := tos[i]
-					expectedTo := string(expectedTos[i])
-					if to != expectedTo {
-						t.Fatalf("expected to %v but got %v", expectedTo, to)
-					}
+				if !slices.Equal(lastEmail.ExtractTos(), []string{tc.payload.EmailTo}) {
+					t.Fatalf("expected to %v but got %v", lastEmail.ExtractTos(), tc.payload.EmailTo)
 				}
 
 				if string(lastEmail.ExtractMessage()) != string(tc.payload.Message) {
@@ -159,19 +149,8 @@ func TestAddPolicyDriver(t *testing.T) {
 
 				lastEmail := testEmail.SendLogs().Last()
 
-				tos := lastEmail.ExtractTos()
-				expectedTos := []string{tc.payload.EmailTo}
-
-				if len(tos) != len(expectedTos) {
-					t.Fatalf("mismatched to lengths, expected %v but got %v", expectedTos, tos)
-				}
-
-				for i := range tos {
-					to := tos[i]
-					expectedTo := string(expectedTos[i])
-					if to != expectedTo {
-						t.Fatalf("expected to %v but got %v", expectedTo, to)
-					}
+				if !slices.Equal(lastEmail.ExtractTos(), []string{tc.payload.EmailTo}) {
+					t.Fatalf("expected to %v but got %v", lastEmail.ExtractTos(), tc.payload.EmailTo)
 				}
 
 				if string(lastEmail.ExtractMessage()) != string(tc.payload.Message) {
@@ -312,40 +291,12 @@ func TestAddPolicyCoverage(t *testing.T) {
 
 				lastEmail := testEmail.SendLogs().Last()
 
-				{
-					// Check all Tos
-					tos := lastEmail.ExtractTos()
-					expectedTos := tc.payload.EmailTo
-
-					if len(tos) != len(expectedTos) {
-						t.Fatalf("mismatched to lengths, expected %v but got %v", expectedTos, tos)
-					}
-
-					for i := range tos {
-						to := tos[i]
-						expectedTo := string(expectedTos[i])
-						if to != expectedTo {
-							t.Fatalf("expected to %v but got %v", expectedTo, to)
-						}
-					}
+				if !slices.Equal(lastEmail.ExtractTos(), tc.payload.EmailTo) {
+					t.Fatalf("expected to %v but got %v", lastEmail.ExtractTos(), tc.payload.EmailTo)
 				}
 
-				{
-					// Check all CCs
-					ccs := lastEmail.ExtractCCs()
-					expectedCCs := tc.payload.EmailCC
-
-					if len(ccs) != len(expectedCCs) {
-						t.Fatalf("mismatched cc lengths, expected %v but got %v", expectedCCs, ccs)
-					}
-
-					for i := range ccs {
-						cc := ccs[i]
-						expectedCC := string(expectedCCs[i])
-						if cc != expectedCC {
-							t.Fatalf("expected cc %v but got %v", expectedCC, cc)
-						}
-					}
+				if !slices.Equal(lastEmail.ExtractCCs(), tc.payload.EmailCC) {
+					t.Fatalf("expected cc %v but got %v", lastEmail.ExtractCCs(), tc.payload.EmailCC)
 				}
 
 				if string(lastEmail.ExtractMessage()) != string(tc.payload.Message) {
@@ -422,19 +373,8 @@ func TestAddPolicyAddress(t *testing.T) {
 
 				lastEmail := testEmail.SendLogs().Last()
 
-				tos := lastEmail.ExtractTos()
-				expectedTos := []string{tc.payload.EmailTo}
-
-				if len(tos) != len(expectedTos) {
-					t.Fatalf("mismatched to lengths, expected %v but got %v", expectedTos, tos)
-				}
-
-				for i := range tos {
-					to := tos[i]
-					expectedTo := string(expectedTos[i])
-					if to != expectedTo {
-						t.Fatalf("expected to %v but got %v", expectedTo, to)
-					}
+				if !slices.Equal(lastEmail.ExtractTos(), []string{tc.payload.EmailTo}) {
+					t.Fatalf("expected to %v but got %v", lastEmail.ExtractTos(), tc.payload.EmailTo)
 				}
 
 				if string(lastEmail.ExtractMessage()) != string(tc.payload.Message) {

--- a/comms/handlers/handlers_test.go
+++ b/comms/handlers/handlers_test.go
@@ -168,6 +168,97 @@ func TestAddPolicyDriver(t *testing.T) {
 	}
 }
 
+func TestAddPolicyCoverage(t *testing.T) {
+
+	t.Parallel()
+
+	type testCase struct {
+		method       string
+		payload      handlers.AddPolicyCoverageReq
+		expectTplID  email.TplID
+		expectStatus int
+	}
+
+	testCases := map[string]testCase{
+		"pass": {
+			method: http.MethodPost,
+			payload: handlers.AddPolicyCoverageReq{
+				EmailTo: "foo@bar.com",
+				EmailCC: "baz@bar.com",
+				Message: json.RawMessage(`{"foo":"bar"}`),
+			},
+			expectTplID:  email.TplAddPolicyCoverage,
+			expectStatus: http.StatusOK,
+		},
+		"fail invalid method": {
+			method:       http.MethodGet,
+			payload:      handlers.AddPolicyCoverageReq{},
+			expectStatus: http.StatusMethodNotAllowed,
+		},
+	}
+
+	testFactory := func(tc testCase) func(*testing.T) {
+		return func(t *testing.T) {
+
+			payload, err := json.Marshal(tc.payload)
+			if err != nil {
+				t.Fatalf("could nor marshal payload to json: %v", err)
+			}
+
+			testEmail := mockemail.NewClient()
+			defer testEmail.FlushSendLogs()
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(tc.method, "/api/comms/add-policy-coverage", bytes.NewReader(payload))
+
+			handlers.AddPolicyCoverage(testEmail)(w, req)
+
+			resp := w.Result()
+
+			if resp.StatusCode != tc.expectStatus {
+				t.Fatalf("expected status %v but got %v", tc.expectStatus, resp.StatusCode)
+			}
+
+			if resp.StatusCode == http.StatusOK {
+
+				if testEmail.SendLogs().IsEmpty() {
+					t.Fatalf("expected email log but got empty")
+				}
+
+				lastEmail := testEmail.SendLogs().Last()
+
+				if lastEmail.ExtractTo() != tc.payload.EmailTo {
+					t.Fatalf("expected to %v but got %v", tc.payload.EmailTo, lastEmail.ExtractTo())
+				}
+
+				lastCC := lastEmail.ExtractCC()
+
+				if len(lastCC) != 1 {
+					t.Fatalf("expected cc %v, none found", tc.payload.EmailCC)
+				}
+
+				cc := lastCC[0]
+
+				if cc != tc.payload.EmailCC {
+					t.Fatalf("expected cc %v but got %v", tc.payload.EmailCC, cc)
+				}
+
+				if string(lastEmail.ExtractMessage()) != string(tc.payload.Message) {
+					t.Fatalf("expected message %v but got %v", tc.payload.Message, lastEmail.ExtractMessage())
+				}
+
+				if lastEmail.ExtractTplID() != tc.expectTplID {
+					t.Fatalf("expected tpl %v but got %v", tc.expectTplID, lastEmail.ExtractTplID())
+				}
+			}
+		}
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, testFactory(tc))
+	}
+}
+
 func TestAddPolicyAddress(t *testing.T) {
 
 	t.Parallel()

--- a/comms/handlers/handlers_test.go
+++ b/comms/handlers/handlers_test.go
@@ -70,8 +70,19 @@ func TestAddPolicyVehicle(t *testing.T) {
 
 				lastEmail := testEmail.SendLogs().Last()
 
-				if lastEmail.ExtractTo() != tc.payload.EmailTo {
-					t.Fatalf("expected to %v but got %v", tc.payload.EmailTo, lastEmail.ExtractTo())
+				tos := lastEmail.ExtractTos()
+				expectedTos := []string{tc.payload.EmailTo}
+
+				if len(tos) != len(expectedTos) {
+					t.Fatalf("mismatched to lengths, expected %v but got %v", expectedTos, tos)
+				}
+
+				for i := range tos {
+					to := tos[i]
+					expectedTo := string(expectedTos[i])
+					if to != expectedTo {
+						t.Fatalf("expected to %v but got %v", expectedTo, to)
+					}
 				}
 
 				if string(lastEmail.ExtractMessage()) != string(tc.payload.Message) {
@@ -148,8 +159,19 @@ func TestAddPolicyDriver(t *testing.T) {
 
 				lastEmail := testEmail.SendLogs().Last()
 
-				if lastEmail.ExtractTo() != tc.payload.EmailTo {
-					t.Fatalf("expected to %v but got %v", tc.payload.EmailTo, lastEmail.ExtractTo())
+				tos := lastEmail.ExtractTos()
+				expectedTos := []string{tc.payload.EmailTo}
+
+				if len(tos) != len(expectedTos) {
+					t.Fatalf("mismatched to lengths, expected %v but got %v", expectedTos, tos)
+				}
+
+				for i := range tos {
+					to := tos[i]
+					expectedTo := string(expectedTos[i])
+					if to != expectedTo {
+						t.Fatalf("expected to %v but got %v", expectedTo, to)
+					}
 				}
 
 				if string(lastEmail.ExtractMessage()) != string(tc.payload.Message) {
@@ -183,8 +205,48 @@ func TestAddPolicyCoverage(t *testing.T) {
 		"pass": {
 			method: http.MethodPost,
 			payload: handlers.AddPolicyCoverageReq{
-				EmailTo: "foo@bar.com",
-				EmailCC: "baz@bar.com",
+				EmailTo: []string{"foo@bar.com"},
+				EmailCC: []string{"baz@bar.com"},
+				Message: json.RawMessage(`{"foo":"bar"}`),
+			},
+			expectTplID:  email.TplAddPolicyCoverage,
+			expectStatus: http.StatusOK,
+		},
+		"pass 2 to": {
+			method: http.MethodPost,
+			payload: handlers.AddPolicyCoverageReq{
+				EmailTo: []string{"foo@bar.com", "foo@baz.com"},
+				EmailCC: []string{"baz@bar.com"},
+				Message: json.RawMessage(`{"foo":"bar"}`),
+			},
+			expectTplID:  email.TplAddPolicyCoverage,
+			expectStatus: http.StatusOK,
+		},
+		"pass 2 cc": {
+			method: http.MethodPost,
+			payload: handlers.AddPolicyCoverageReq{
+				EmailTo: []string{"baz@bar.com"},
+				EmailCC: []string{"foo@bar.com", "foo@baz.com"},
+				Message: json.RawMessage(`{"foo":"bar"}`),
+			},
+			expectTplID:  email.TplAddPolicyCoverage,
+			expectStatus: http.StatusOK,
+		},
+		"pass 2 to and 2 cc": {
+			method: http.MethodPost,
+			payload: handlers.AddPolicyCoverageReq{
+				EmailTo: []string{"baz@bar.com", "fizz@buzz.com"},
+				EmailCC: []string{"foo@bar.com", "foo@baz.com"},
+				Message: json.RawMessage(`{"foo":"bar"}`),
+			},
+			expectTplID:  email.TplAddPolicyCoverage,
+			expectStatus: http.StatusOK,
+		},
+		"pass many": {
+			method: http.MethodPost,
+			payload: handlers.AddPolicyCoverageReq{
+				EmailTo: []string{"baz@bar.com", "fizz@buzz.com", "beep@boop.com"},
+				EmailCC: []string{"foo@bar.com", "foo@baz.com", "zig@zag.com"},
 				Message: json.RawMessage(`{"foo":"bar"}`),
 			},
 			expectTplID:  email.TplAddPolicyCoverage,
@@ -227,20 +289,40 @@ func TestAddPolicyCoverage(t *testing.T) {
 
 				lastEmail := testEmail.SendLogs().Last()
 
-				if lastEmail.ExtractTo() != tc.payload.EmailTo {
-					t.Fatalf("expected to %v but got %v", tc.payload.EmailTo, lastEmail.ExtractTo())
+				{
+					// Check all Tos
+					tos := lastEmail.ExtractTos()
+					expectedTos := tc.payload.EmailTo
+
+					if len(tos) != len(expectedTos) {
+						t.Fatalf("mismatched to lengths, expected %v but got %v", expectedTos, tos)
+					}
+
+					for i := range tos {
+						to := tos[i]
+						expectedTo := string(expectedTos[i])
+						if to != expectedTo {
+							t.Fatalf("expected to %v but got %v", expectedTo, to)
+						}
+					}
 				}
 
-				lastCC := lastEmail.ExtractCC()
+				{
+					// Check all CCs
+					ccs := lastEmail.ExtractCCs()
+					expectedCCs := tc.payload.EmailCC
 
-				if len(lastCC) != 1 {
-					t.Fatalf("expected cc %v, none found", tc.payload.EmailCC)
-				}
+					if len(ccs) != len(expectedCCs) {
+						t.Fatalf("mismatched cc lengths, expected %v but got %v", expectedCCs, ccs)
+					}
 
-				cc := lastCC[0]
-
-				if cc != tc.payload.EmailCC {
-					t.Fatalf("expected cc %v but got %v", tc.payload.EmailCC, cc)
+					for i := range ccs {
+						cc := ccs[i]
+						expectedCC := string(expectedCCs[i])
+						if cc != expectedCC {
+							t.Fatalf("expected cc %v but got %v", expectedCC, cc)
+						}
+					}
 				}
 
 				if string(lastEmail.ExtractMessage()) != string(tc.payload.Message) {
@@ -317,8 +399,19 @@ func TestAddPolicyAddress(t *testing.T) {
 
 				lastEmail := testEmail.SendLogs().Last()
 
-				if lastEmail.ExtractTo() != tc.payload.EmailTo {
-					t.Fatalf("expected to %v but got %v", tc.payload.EmailTo, lastEmail.ExtractTo())
+				tos := lastEmail.ExtractTos()
+				expectedTos := []string{tc.payload.EmailTo}
+
+				if len(tos) != len(expectedTos) {
+					t.Fatalf("mismatched to lengths, expected %v but got %v", expectedTos, tos)
+				}
+
+				for i := range tos {
+					to := tos[i]
+					expectedTo := string(expectedTos[i])
+					if to != expectedTo {
+						t.Fatalf("expected to %v but got %v", expectedTo, to)
+					}
 				}
 
 				if string(lastEmail.ExtractMessage()) != string(tc.payload.Message) {

--- a/comms/handlers/models.go
+++ b/comms/handlers/models.go
@@ -15,8 +15,8 @@ type AddPolicyDriverReq struct {
 }
 
 type AddPolicyCoverageReq struct {
-	EmailTo string          `json:"email_to"`
-	EmailCC string          `json:"email_cc"`
+	EmailTo []string        `json:"email_to"`
+	EmailCC []string        `json:"email_cc"`
 	Message json.RawMessage `json:"message"`
 }
 

--- a/comms/handlers/models.go
+++ b/comms/handlers/models.go
@@ -14,6 +14,12 @@ type AddPolicyDriverReq struct {
 	Message json.RawMessage `json:"message"`
 }
 
+type AddPolicyCoverageReq struct {
+	EmailTo string          `json:"email_to"`
+	EmailCC string          `json:"email_cc"`
+	Message json.RawMessage `json:"message"`
+}
+
 type AddPolicyAddressReq struct {
 	EmailTo string          `json:"email_to"`
 	Message json.RawMessage `json:"message"`

--- a/comms/main.go
+++ b/comms/main.go
@@ -34,6 +34,7 @@ func main() {
 	// setup the api routes
 	http.HandleFunc("/api/comms/add-policy-vehicle", handlers.AddPolicyVehicle(emailsvc))
 	http.HandleFunc("/api/comms/add-policy-driver", handlers.AddPolicyDriver(emailsvc))
+	http.HandleFunc("/api/comms/add-policy-coverage", handlers.AddPolicyCoverage(emailsvc))
 	http.HandleFunc("/api/comms/add-policy-address", handlers.AddPolicyAddress(emailsvc))
 
 	// start the api server


### PR DESCRIPTION
- This PR adds the new `add-policy-coverage-route` which takes a new `CC` parameter
- To support passing this `CC` parameter through, `email.Send` was changed to also accept a list of strings for `CC` and the implementations were updated. I opted to modify `Send` this was as it lets us easily pass future `CC` values through if we wish to and it can be easily defaulted today.