### PR TITLE
added: new handler, tests, and updates allowing cc sending for policy coverage

### DIFF
--- a/comms/README.md
+++ b/comms/README.md
@@ -12,6 +12,6 @@ The comms api needs to support a new operation for adding policy coverage. The n
 
 **Instructions:** 
 
-* [ ] Create a handler for the new comms operation and implement the correct business logic inside of the handler.
-* [ ] Make whatever improvements are needed to support the new email `CC` field.
-* [ ] Create a unit test for the new handler to prove it meets business requirements.
+* [x] Create a handler for the new comms operation and implement the correct business logic inside of the handler.
+* [x] Make whatever improvements are needed to support the new email `CC` field.
+* [x] Create a unit test for the new handler to prove it meets business requirements.

--- a/comms/email/email.go
+++ b/comms/email/email.go
@@ -5,11 +5,12 @@ import "encoding/json"
 type TplID string
 
 const (
-	TplAddPolicyVehicle TplID = "add-policy-vehicle"
-	TplAddPolicyDriver  TplID = "add-policy-driver"
-	TplAddPolicyAddress TplID = "add-policy-address"
+	TplAddPolicyVehicle  TplID = "add-policy-vehicle"
+	TplAddPolicyDriver   TplID = "add-policy-driver"
+	TplAddPolicyAddress  TplID = "add-policy-address"
+	TplAddPolicyCoverage TplID = "add-policy-coverage"
 )
 
 type MailProvider interface {
-	Send(to []string, message json.RawMessage, tpl TplID) error
+	Send(to []string, cc []string, message json.RawMessage, tpl TplID) error
 }

--- a/comms/email/mockemail/mockemail.go
+++ b/comms/email/mockemail/mockemail.go
@@ -2,6 +2,7 @@ package mockemail
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/gloveboxhq/glovebox-go-code-challenge/comms/email"
 )
@@ -16,11 +17,12 @@ func NewClient() *Client {
 	}
 }
 
-func (c *Client) Send(to []string, message json.RawMessage, tplID email.TplID) error {
+func (c *Client) Send(to []string, cc []string, message json.RawMessage, tplID email.TplID) error {
 
 	for _, v := range to {
 		c.sendLogs = append(c.sendLogs, SendLog{
 			to:      v,
+			cc:      strings.Join(cc, ","),
 			message: message,
 			tplID:   tplID,
 		})

--- a/comms/email/mockemail/mockemail.go
+++ b/comms/email/mockemail/mockemail.go
@@ -2,7 +2,6 @@ package mockemail
 
 import (
 	"encoding/json"
-	"strings"
 
 	"github.com/gloveboxhq/glovebox-go-code-challenge/comms/email"
 )
@@ -18,15 +17,12 @@ func NewClient() *Client {
 }
 
 func (c *Client) Send(to []string, cc []string, message json.RawMessage, tplID email.TplID) error {
-
-	for _, v := range to {
-		c.sendLogs = append(c.sendLogs, SendLog{
-			to:      v,
-			cc:      strings.Join(cc, ","),
-			message: message,
-			tplID:   tplID,
-		})
-	}
+	c.sendLogs = append(c.sendLogs, SendLog{
+		to:      to,
+		cc:      cc,
+		message: message,
+		tplID:   tplID,
+	})
 
 	return nil
 }

--- a/comms/email/mockemail/sendlog.go
+++ b/comms/email/mockemail/sendlog.go
@@ -8,12 +8,17 @@ import (
 
 type SendLog struct {
 	to      string
+	cc      string
 	tplID   email.TplID
 	message json.RawMessage
 }
 
 func (sl *SendLog) ExtractTo() string {
 	return sl.to
+}
+
+func (sl *SendLog) ExtractCc() string {
+	return sl.cc
 }
 
 func (sl *SendLog) ExtractTplID() email.TplID {

--- a/comms/email/mockemail/sendlog.go
+++ b/comms/email/mockemail/sendlog.go
@@ -7,17 +7,17 @@ import (
 )
 
 type SendLog struct {
-	to      string
-	cc      string
+	to      []string
+	cc      []string
 	tplID   email.TplID
 	message json.RawMessage
 }
 
-func (sl *SendLog) ExtractTo() string {
+func (sl *SendLog) ExtractTos() []string {
 	return sl.to
 }
 
-func (sl *SendLog) ExtractCc() string {
+func (sl *SendLog) ExtractCcs() []string {
 	return sl.cc
 }
 
@@ -32,10 +32,7 @@ func (sl *SendLog) ExtractMessage() json.RawMessage {
 type SendLogs []SendLog
 
 func (s SendLogs) IsEmpty() bool {
-	if len(s) == 0 {
-		return true
-	}
-	return false
+	return len(s) == 0
 }
 
 // Last will return the last created log

--- a/comms/email/sendgrid/sendgrid.go
+++ b/comms/email/sendgrid/sendgrid.go
@@ -30,11 +30,12 @@ type Client struct {
 	fromName    string
 }
 
-func (c *Client) Send(to []string, message json.RawMessage, tpl email.TplID) error {
+func (c *Client) Send(to []string, cc []string, message json.RawMessage, tpl email.TplID) error {
 
 	// create personalization
 	p := mail.NewPersonalization().
-		AddTos(to...)
+		AddTos(to...).
+		AddCCs(cc...)
 
 	// create the email
 	m := mail.NewV3Mail().

--- a/comms/email/sendgrid/sendgrid.go
+++ b/comms/email/sendgrid/sendgrid.go
@@ -31,7 +31,6 @@ type Client struct {
 }
 
 func (c *Client) Send(to []string, cc []string, message json.RawMessage, tpl email.TplID) error {
-
 	// create personalization
 	p := mail.NewPersonalization().
 		AddTos(to...).

--- a/comms/handlers/handlers.go
+++ b/comms/handlers/handlers.go
@@ -23,7 +23,7 @@ func AddPolicyVehicle(emailsvc email.MailProvider) http.HandlerFunc {
 			return
 		}
 
-		if err := emailsvc.Send([]string{payload.EmailTo}, payload.Message, email.TplAddPolicyVehicle); err != nil {
+		if err := emailsvc.Send([]string{payload.EmailTo}, nil, payload.Message, email.TplAddPolicyVehicle); err != nil {
 			http.Error(w, fmt.Sprintf("error sending email: %v", err), http.StatusInternalServerError)
 			return
 		}
@@ -44,7 +44,7 @@ func AddPolicyDriver(emailsvc email.MailProvider) http.HandlerFunc {
 			return
 		}
 
-		if err := emailsvc.Send([]string{payload.EmailTo}, payload.Message, email.TplAddPolicyDriver); err != nil {
+		if err := emailsvc.Send([]string{payload.EmailTo}, nil, payload.Message, email.TplAddPolicyDriver); err != nil {
 			http.Error(w, fmt.Sprintf("error sending email: %v", err), http.StatusInternalServerError)
 			return
 		}
@@ -65,7 +65,28 @@ func AddPolicyAddress(emailsvc email.MailProvider) http.HandlerFunc {
 			return
 		}
 
-		if err := emailsvc.Send([]string{payload.EmailTo}, payload.Message, email.TplAddPolicyAddress); err != nil {
+		if err := emailsvc.Send([]string{payload.EmailTo}, nil, payload.Message, email.TplAddPolicyAddress); err != nil {
+			http.Error(w, fmt.Sprintf("error sending email: %v", err), http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
+func AddPolicyCoverage(emailsvc email.MailProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+
+		payload := AddPolicyCoverageReq{}
+
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "invalid payload", http.StatusBadRequest)
+			return
+		}
+
+		if err := emailsvc.Send([]string{payload.EmailTo}, []string{payload.EmailCc}, payload.Message, email.TplAddPolicyCoverage); err != nil {
 			http.Error(w, fmt.Sprintf("error sending email: %v", err), http.StatusInternalServerError)
 			return
 		}

--- a/comms/handlers/handlers_test.go
+++ b/comms/handlers/handlers_test.go
@@ -245,3 +245,86 @@ func TestAddPolicyAddress(t *testing.T) {
 		t.Run(name, testFactory(tc))
 	}
 }
+
+func TestAddPolicyCoverage(t *testing.T) {
+
+	t.Parallel()
+
+	type testCase struct {
+		method       string
+		payload      handlers.AddPolicyCoverageReq
+		expectTplID  email.TplID
+		expectStatus int
+	}
+
+	testCases := map[string]testCase{
+		"pass": {
+			method: http.MethodPost,
+			payload: handlers.AddPolicyCoverageReq{
+				EmailTo: "foo@bar.com",
+				EmailCc: "baz@bar.com",
+				Message: json.RawMessage(`{"foo":"bar"}`),
+			},
+			expectTplID:  email.TplAddPolicyCoverage,
+			expectStatus: http.StatusOK,
+		},
+		"fail invalid method": {
+			method:       http.MethodGet,
+			payload:      handlers.AddPolicyCoverageReq{},
+			expectStatus: http.StatusMethodNotAllowed,
+		},
+	}
+
+	testFactory := func(tc testCase) func(*testing.T) {
+		return func(t *testing.T) {
+
+			payload, err := json.Marshal(tc.payload)
+			if err != nil {
+				t.Fatalf("could nor marshal payload to json: %v", err)
+			}
+
+			testEmail := mockemail.NewClient()
+			defer testEmail.FlushSendLogs()
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(tc.method, "/api/comms/add-policy-coverage", bytes.NewReader(payload))
+
+			handlers.AddPolicyCoverage(testEmail)(w, req)
+
+			resp := w.Result()
+
+			if resp.StatusCode != tc.expectStatus {
+				t.Fatalf("expected status %v but got %v", tc.expectStatus, resp.StatusCode)
+			}
+
+			if resp.StatusCode == http.StatusOK {
+
+				if testEmail.SendLogs().IsEmpty() {
+					t.Fatalf("expected email log but got empty")
+				}
+
+				lastEmail := testEmail.SendLogs().Last()
+
+				if lastEmail.ExtractTo() != tc.payload.EmailTo {
+					t.Fatalf("expected to %v but got %v", tc.payload.EmailTo, lastEmail.ExtractTo())
+				}
+
+				if lastEmail.ExtractCc() != tc.payload.EmailCc {
+					t.Fatalf("expected cc %v but got %v", tc.payload.EmailTo, lastEmail.ExtractTo())
+				}
+
+				if string(lastEmail.ExtractMessage()) != string(tc.payload.Message) {
+					t.Fatalf("expected message %v but got %v", tc.payload.Message, lastEmail.ExtractMessage())
+				}
+
+				if lastEmail.ExtractTplID() != tc.expectTplID {
+					t.Fatalf("expected tpl %v but got %v", tc.expectTplID, lastEmail.ExtractTplID())
+				}
+			}
+		}
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, testFactory(tc))
+	}
+}

--- a/comms/handlers/handlers_test.go
+++ b/comms/handlers/handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/gloveboxhq/glovebox-go-code-challenge/comms/email"
@@ -70,8 +71,8 @@ func TestAddPolicyVehicle(t *testing.T) {
 
 				lastEmail := testEmail.SendLogs().Last()
 
-				if lastEmail.ExtractTo() != tc.payload.EmailTo {
-					t.Fatalf("expected to %v but got %v", tc.payload.EmailTo, lastEmail.ExtractTo())
+				if lastEmail.ExtractTos()[0] != tc.payload.EmailTo {
+					t.Fatalf("expected to %v but got %v", tc.payload.EmailTo, lastEmail.ExtractTos())
 				}
 
 				if string(lastEmail.ExtractMessage()) != string(tc.payload.Message) {
@@ -148,8 +149,8 @@ func TestAddPolicyDriver(t *testing.T) {
 
 				lastEmail := testEmail.SendLogs().Last()
 
-				if lastEmail.ExtractTo() != tc.payload.EmailTo {
-					t.Fatalf("expected to %v but got %v", tc.payload.EmailTo, lastEmail.ExtractTo())
+				if lastEmail.ExtractTos()[0] != tc.payload.EmailTo {
+					t.Fatalf("expected to %v but got %v", tc.payload.EmailTo, lastEmail.ExtractTos())
 				}
 
 				if string(lastEmail.ExtractMessage()) != string(tc.payload.Message) {
@@ -226,8 +227,8 @@ func TestAddPolicyAddress(t *testing.T) {
 
 				lastEmail := testEmail.SendLogs().Last()
 
-				if lastEmail.ExtractTo() != tc.payload.EmailTo {
-					t.Fatalf("expected to %v but got %v", tc.payload.EmailTo, lastEmail.ExtractTo())
+				if lastEmail.ExtractTos()[0] != tc.payload.EmailTo {
+					t.Fatalf("expected to %v but got %v", tc.payload.EmailTo, lastEmail.ExtractTos())
 				}
 
 				if string(lastEmail.ExtractMessage()) != string(tc.payload.Message) {
@@ -305,12 +306,12 @@ func TestAddPolicyCoverage(t *testing.T) {
 
 				lastEmail := testEmail.SendLogs().Last()
 
-				if lastEmail.ExtractTo() != tc.payload.EmailTo {
-					t.Fatalf("expected to %v but got %v", tc.payload.EmailTo, lastEmail.ExtractTo())
+				if !slices.Equal(lastEmail.ExtractTos(), []string{tc.payload.EmailTo}) {
+					t.Fatalf("expected %v but got %v", lastEmail.ExtractTos(), tc.payload.EmailTo)
 				}
 
-				if lastEmail.ExtractCc() != tc.payload.EmailCc {
-					t.Fatalf("expected cc %v but got %v", tc.payload.EmailTo, lastEmail.ExtractTo())
+				if !slices.Equal(lastEmail.ExtractCcs(), []string{tc.payload.EmailCc}) {
+					t.Fatalf("expected %v but got %v", lastEmail.ExtractCcs(), tc.payload.EmailCc)
 				}
 
 				if string(lastEmail.ExtractMessage()) != string(tc.payload.Message) {

--- a/comms/handlers/models.go
+++ b/comms/handlers/models.go
@@ -15,6 +15,13 @@ type AddPolicyDriverReq struct {
 }
 
 type AddPolicyAddressReq struct {
+	EmailTo string `json:"email_to"`
+
+	Message json.RawMessage `json:"message"`
+}
+
+type AddPolicyCoverageReq struct {
 	EmailTo string          `json:"email_to"`
+	EmailCc string          `json:"email_cc"`
 	Message json.RawMessage `json:"message"`
 }

--- a/comms/handlers/models.go
+++ b/comms/handlers/models.go
@@ -15,8 +15,7 @@ type AddPolicyDriverReq struct {
 }
 
 type AddPolicyAddressReq struct {
-	EmailTo string `json:"email_to"`
-
+	EmailTo string          `json:"email_to"`
 	Message json.RawMessage `json:"message"`
 }
 

--- a/comms/main.go
+++ b/comms/main.go
@@ -35,6 +35,7 @@ func main() {
 	http.HandleFunc("/api/comms/add-policy-vehicle", handlers.AddPolicyVehicle(emailsvc))
 	http.HandleFunc("/api/comms/add-policy-driver", handlers.AddPolicyDriver(emailsvc))
 	http.HandleFunc("/api/comms/add-policy-address", handlers.AddPolicyAddress(emailsvc))
+	http.HandleFunc("/api/comms/add-policy-coverage", handlers.AddPolicyCoverage(emailsvc))
 
 	// start the api server
 	log.Print("starting server...")


### PR DESCRIPTION
## Created
- new handler and for the `add-policy-coverage` endpoint

**Endpoint** `/api/comms/add-policy-coverage` **Method** `[POST]`
```json
{
    "email_to": "foo@bar.com",
    "email_cc": "baz@bar.com",
    "message": "some message"
}
```
- new model to support policy coverage requirements and email cc'ing capability
- test case to support handler including new email CC field checking

## Updated
- `MailProvider` interface to support the additional param `cc []string`
- `SendLog` to include cc field in log output as well as an `ExtractCC` method for checking CC field values.
- Email client to include `AddCCs(cc...)` personalization for sending

## Notes

1. Mail providing client offers the opportunity to send batch emails however requirements only specify a single email address.
2. SendLog concatenates CC corespondent data into CSV format, this will break test-case if multiple CC's allowed at req. level
3. To avoid repeating models suggest conversation around using embedded struct fields for similar requirements ( see below )

```go
type AddPolicyBaseReqs struct {
	EmailTo string          `json:"email_to"`
	Message json.RawMessage `json:"message"`
}

type AddPolicyVehicleReq struct {
	AddPolicyBaseReqs
}

type AddPolicyDriverReq struct {
	AddPolicyBaseReqs
}

type AddPolicyCoverageReq struct {
	AddPolicyBaseReqs
	EmailCc string          `json:"email_cc"`
}
```

* [x] Fork this repository and make your changes directly within the appropriate challenge directory.
* [x] When complete, send in a pull request for code review.
* [x] Ensure that before you send the PR that the main application compiles and runs, the tests all pass, and your commits are all squashed into a single commit.
